### PR TITLE
fix: CE-573-Missing-UK-Constraint-on-action_type_action_xref

### DIFF
--- a/migrations/sql/V1.17.0__CE-573.sql
+++ b/migrations/sql/V1.17.0__CE-573.sql
@@ -1,0 +1,2 @@
+alter table if exists case_management.action_type_action_xref
+    add constraint "UK_action_type_action_xref__action_type_code__action_code" unique (action_type_code, action_code);


### PR DESCRIPTION
# Description

This change is to resolve the issue with duplicate action codes.  It adds a unique constraints to the action_type_action_xref table that prevents inserting records with the same combination of action_code and action_type_code.

Fixes # (CE-573)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] After the database container is fully initialized try to run the following SQL statement  `INSERT INTO case_management.action_type_action_xref(
	action_type_code, action_code, display_order, active_ind, create_user_id, create_utc_timestamp)
	VALUES ('COMPASSESS', 'ASSESSHIST', 3, 'Y', CURRENT_USER, CURRENT_TIMESTAMP);`
It should return an error that indicates that inserting duplicate actions is no longer possible



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-compliance-enforcement-cm-41-backend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement-cm/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement-cm/actions/workflows/merge.yml)