### PR TITLE
feat: 557-add-the-ability-to-indicate-whether-or-not-a-trap-captured-an-animal

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -129,6 +129,7 @@ model equipment_code {
   create_utc_timestamp                               DateTime    @db.Timestamp(6)
   update_user_id                                     String      @db.VarChar(32)
   update_utc_timestamp                               DateTime    @db.Timestamp(6)
+  is_trap_ind                                        Boolean     @default(false)
   equipment_equipment_equipment_codeToequipment_code equipment[] @relation("equipment_equipment_codeToequipment_code")
 }
 
@@ -342,6 +343,7 @@ model equipment {
   create_utc_timestamp                                    DateTime                 @db.Timestamp(6)
   update_user_id                                          String                   @db.VarChar(32)
   update_utc_timestamp                                    DateTime                 @db.Timestamp(6)
+  was_animal_captured                                     String                   @default("U") @db.Char(1)
   action                                                  action[]
   equipment_code_equipment_equipment_codeToequipment_code equipment_code?          @relation("equipment_equipment_codeToequipment_code", fields: [equipment_code], references: [equipment_code], onDelete: NoAction, onUpdate: NoAction, map: "fk_equipment__equipment_code")
 }

--- a/backend/src/case_file/case_file.service.ts
+++ b/backend/src/case_file/case_file.service.ts
@@ -959,6 +959,7 @@ export class CaseFileService {
           update_utc_timestamp: createdDate,
           equipment_code: createEquipmentInput.equipment[0].typeCode,
           equipment_location_desc: createEquipmentInput.equipment[0].address,
+          was_animal_captured: createEquipmentInput.equipment[0].wasAnimalCaptured,
           // exclude equipment_geometry_point because prisma can't handle this =gracefully
         };
 
@@ -1066,6 +1067,7 @@ export class CaseFileService {
           equipment_code: equipmentRecord.typeCode,
           equipment_location_desc: equipmentRecord.address,
           active_ind: equipmentRecord.actionEquipmentTypeActiveIndicator,
+          was_animal_captured: equipmentRecord.wasAnimalCaptured,
         };
 
         // Update the equipment record
@@ -1274,6 +1276,7 @@ export class CaseFileService {
             yCoordinate: latitudeString,
             createDate: create_utc_timestamp,
             actions: [],
+            wasAnimalCaptured: equipment.was_animal_captured,
           } as Equipment);
 
         this.logger.debug(`Equipment type: ${equipment.equipment_code}`);

--- a/backend/src/case_file/case_file_inputs.graphql
+++ b/backend/src/case_file/case_file_inputs.graphql
@@ -128,6 +128,7 @@ input EquipmentDetailsInput {
   xCoordinate: String
   yCoordinate: String
   actions: [EquipmentActionInput]!
+  wasAnimalCaptured: String
 }
 
 input EquipmentActionInput {

--- a/backend/src/case_file/case_file_types.graphql
+++ b/backend/src/case_file/case_file_types.graphql
@@ -38,4 +38,5 @@ type EquipmentDetails {
   yCoordinate: String
   createDate: Date
   actions: [CaseFileAction]
+  wasAnimalCaptured: String
 }

--- a/backend/src/case_file/dto/equipment/create-equipment-details.input.ts
+++ b/backend/src/case_file/dto/equipment/create-equipment-details.input.ts
@@ -7,4 +7,5 @@ export interface CreateEquipmentDetailsInput {
   yCoordinate: string;
   equipmentTypeActiveIndicator: boolean;
   actions: EquipmentActionItem[];
+  wasAnimalCaptured: string;
 }

--- a/backend/src/case_file/dto/equipment/update-equipment-details.input.ts
+++ b/backend/src/case_file/dto/equipment/update-equipment-details.input.ts
@@ -8,4 +8,5 @@ export interface UpdateEquipmentDetailsInput {
   yCoordinate: string;
   actionEquipmentTypeActiveIndicator: boolean;
   actions: EquipmentActionItem[];
+  wasAnimalCaptured: string;
 }

--- a/backend/src/case_file/entities/equipment.entity.ts
+++ b/backend/src/case_file/entities/equipment.entity.ts
@@ -11,4 +11,5 @@ export class Equipment {
   yCoordinate?: string;
   createDate: Date;
   actions: CaseFileAction[];
+  wasAnimalCaptured: string;
 }

--- a/backend/src/equipment_code/entities/equipment_code.entity.ts
+++ b/backend/src/equipment_code/entities/equipment_code.entity.ts
@@ -4,4 +4,5 @@ export class EquipmentCode {
   longDescription: string;
   displayOrder: number;
   activeIndicator: boolean;
+  isTrapIndicator: boolean;
 }

--- a/backend/src/equipment_code/equipment_code.graphql
+++ b/backend/src/equipment_code/equipment_code.graphql
@@ -4,6 +4,7 @@ type EquipmentCode {
   longDescription: String
   displayOrder: Int
   activeIndicator: Boolean
+  isTrapIndicator: Boolean
 }
 
 type Query {

--- a/backend/src/equipment_code/equipment_code.service.ts
+++ b/backend/src/equipment_code/equipment_code.service.ts
@@ -14,6 +14,7 @@ export class EquipmentCodeService {
         long_description: true,
         display_order: true,
         active_ind: true,
+        is_trap_ind: true,
       },
     });
 
@@ -23,6 +24,7 @@ export class EquipmentCodeService {
       longDescription: prismaEquipmentCodes.long_description,
       displayOrder: prismaEquipmentCodes.display_order,
       activeIndicator: prismaEquipmentCodes.active_ind,
+      isTrapIndicator: prismaEquipmentCodes.is_trap_ind,
     }));
 
     return equipmentCodes;

--- a/migrations/sql/R__0.16.3__CE-557.sql
+++ b/migrations/sql/R__0.16.3__CE-557.sql
@@ -1,0 +1,1 @@
+update case_management.equipment_code set is_trap_ind = false where equipment_code = 'SIGNG' or equipment_code = 'TRCAM'

--- a/migrations/sql/V1.17.2__CE-557.sql
+++ b/migrations/sql/V1.17.2__CE-557.sql
@@ -1,0 +1,8 @@
+ALTER TABLE case_management.equipment
+  ADD COLUMN IF NOT EXISTS was_animal_captured char(1) NOT NULL DEFAULT 'U';
+
+ALTER TABLE case_management.equipment_code
+  ADD COLUMN IF NOT EXISTS is_trap_ind boolean NOT NULL DEFAULT false;
+
+comment on column case_management.equipment.was_animal_captured is 'Indicates if an animal was captured by the EQUIPMENT. Values are limited to ''Y'' (Yes) ''N'' (No) and ''U'' (Unknown - Not Specified Yet). The default is ''U''';
+comment on column case_management.equipment_code.is_trap_ind is 'Indicates if the EQUIPMENT_CODE value represents a trap.   Default to ''true''.   For EQUIPMENT_CODE values such as Signage or Trail cameras the value is ''false''';

--- a/migrations/sql/V1.17.2__CE-557.sql
+++ b/migrations/sql/V1.17.2__CE-557.sql
@@ -2,7 +2,10 @@ ALTER TABLE case_management.equipment
   ADD COLUMN IF NOT EXISTS was_animal_captured char(1) NOT NULL DEFAULT 'U';
 
 ALTER TABLE case_management.equipment_code
-  ADD COLUMN IF NOT EXISTS is_trap_ind boolean NOT NULL DEFAULT false;
+  ADD COLUMN IF NOT EXISTS is_trap_ind boolean NOT NULL DEFAULT true;
+
+UPDATE case_management.configuration
+SET configuration_value = cast(configuration_value as INTEGER)+1 WHERE configuration_code = 'CDTABLEVER';
 
 comment on column case_management.equipment.was_animal_captured is 'Indicates if an animal was captured by the EQUIPMENT. Values are limited to ''Y'' (Yes) ''N'' (No) and ''U'' (Unknown - Not Specified Yet). The default is ''U''';
 comment on column case_management.equipment_code.is_trap_ind is 'Indicates if the EQUIPMENT_CODE value represents a trap.   Default to ''true''.   For EQUIPMENT_CODE values such as Signage or Trail cameras the value is ''false''';


### PR DESCRIPTION
# Description

This PR makes possible to indicate whether or not a trap has resulted in a capture of an animal.

Fixes # (CE-557)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] See details in the corresponding Complaint Management PR

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-compliance-enforcement-cm-62-backend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement-cm/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement-cm/actions/workflows/merge.yml)