### PR TITLE
feat: wire up ephemeral crunchy dev databases

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -64,6 +64,12 @@ jobs:
         run: |
           DEPLOYMENT_NUMBER=${{ steps.get-deployment-number.outputs.DEPLOYMENT_NUMBER }}
           ./.github/scripts/gitops.sh disable dev-$DEPLOYMENT_NUMBER
+
+      # We always run this to avoid deleting developer databases on commit pushes after a PR is opened
+      # there is a small edge case where a cleanup could be interrupted by this if 2 PRs open closely together
+      - name: Unset / No-op Crunchy development DB cleanup
+        run: |
+          ./.github/scripts/crunchy.sh u
     
       - name: Commit and push update
         run: |

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -78,6 +78,19 @@ jobs:
           ./.github/scripts/gitops.sh tag dev-$DEPLOYMENT_NUMBER ${{ needs.builds.outputs.sha }}
           ./.github/scripts/gitops.sh enable dev-$DEPLOYMENT_NUMBER
 
+      # We always run this to avoid deleting developer databases on commit pushes after a PR is opened
+      # there is a small edge case where a cleanup could be interrupted by this if 2 PRs open closely together
+      - name: Unset / No-op Crunchy development DB cleanup
+        run: |
+          ./.github/scripts/crunchy.sh u
+
+      # On a newly opened PR we drop the old database and crunchy will standup a fresh db
+      - name: Refresh developer database for newly opened PR
+        if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened') }}
+        run: |
+          DEPLOYMENT_NUMBER=${{ steps.get-deployment-number.outputs.DEPLOYMENT_NUMBER }}
+          ./.github/scripts/crunchy.sh s $DEPLOYMENT_NUMBER
+
       - name: Commit and push update
         shell: bash
         run: |


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Crunchy is already rolled out in dev/test and awaiting prod
- the TLDR; of this is when we run the script in the actions, it sets a value in the crunchy values file in the gitops repo from `null` to a integer ID, when this value is NOT `null` it will cause argo to spin up a job which deletes and refreshes the database for the dev

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
