### PR TITLE
fix: CE-177 Code Tables Need Simplified Audit Trigger

### DIFF
--- a/migrations/sql/V1.49.0__CE-177_audit_trigger.sql
+++ b/migrations/sql/V1.49.0__CE-177_audit_trigger.sql
@@ -1,0 +1,140 @@
+CREATE OR REPLACE FUNCTION case_management.update_audit_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+calling_query TEXT;
+update_user_id_found BOOL;
+BEGIN
+        IF NEW.update_utc_timestamp IS NOT DISTINCT FROM OLD.update_utc_timestamp THEN
+            NEW.update_utc_timestamp := CURRENT_TIMESTAMP;
+        END IF;
+        SELECT current_query() INTO calling_query;
+        SELECT POSITION('update_user_id' IN calling_query) > 0 INTO update_user_id_found;
+        IF update_user_id_found = 'f' THEN
+            NEW.update_user_id := CURRENT_USER;
+        END IF;
+        RETURN NEW;
+    END; 
+$function$
+;
+
+CREATE TRIGGER agecode_set_default_audit_values
+BEFORE update on case_management.age_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER acttpactxref_set_default_audit_values
+BEFORE update on case_management.action_type_action_xref
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER actcd_set_default_audit_values
+BEFORE update on case_management.action_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER acttpcd_set_default_audit_values
+BEFORE update on case_management.action_type_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER caselcncd_set_default_audit_values
+BEFORE update on case_management.case_location_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER cnfthistcd_set_default_audit_values
+BEFORE update on case_management.conflict_history_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER dischargecd_set_default_audit_values
+BEFORE update on case_management.discharge_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER drgmethdcd_set_default_audit_values
+BEFORE update on case_management.drug_method_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER drgrmotmcd_set_default_audit_values
+BEFORE update on case_management.drug_remaining_outcome_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER drugcd_set_default_audit_values
+BEFORE update on case_management.drug_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER earcode_set_default_audit_values
+BEFORE update on case_management.ear_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER equipmntcd_set_default_audit_values
+BEFORE update on case_management.equipment_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER equipmntstcd_set_default_audit_values
+BEFORE update on case_management.equipment_status_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER hwcotcmactbycd_set_default_audit_values
+BEFORE update on case_management.hwcr_outcome_actioned_by_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER agencycd_set_default_audit_values
+BEFORE update on case_management.agency_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER ipmathctgrcd_set_default_audit_values
+BEFORE update on case_management.ipm_auth_category_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER inactnrsncd_set_default_audit_values
+BEFORE update on case_management.inaction_reason_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER noncompdnmtxcd_set_default_audit_values
+BEFORE update on case_management.non_compliance_decision_matrix_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER schlcd_set_default_audit_values
+BEFORE update on case_management.schedule_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER shlstrxref_set_default_audit_values
+BEFORE update on case_management.schedule_sector_xref
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER strcd_set_default_audit_values
+BEFORE update on case_management.sector_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER sexcd_set_default_audit_values
+BEFORE update on case_management.sex_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER thrtlvlcd_set_default_audit_values
+BEFORE update on case_management.threat_level_code
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();
+
+CREATE TRIGGER wldlf_set_default_audit_values
+BEFORE update on case_management.wildlife
+FOR EACH ROW
+EXECUTE FUNCTION case_management.update_audit_columns();

--- a/migrations/sql/shared/V1.49.1__CE-177_audit_trigger.sql
+++ b/migrations/sql/shared/V1.49.1__CE-177_audit_trigger.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION shared.update_audit_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+calling_query TEXT;
+update_user_id_found BOOL;
+BEGIN
+        IF NEW.update_utc_timestamp IS NOT DISTINCT FROM OLD.update_utc_timestamp THEN
+            NEW.update_utc_timestamp := CURRENT_TIMESTAMP;
+        END IF;
+        SELECT current_query() INTO calling_query;
+        SELECT POSITION('update_user_id' IN calling_query) > 0 INTO update_user_id_found;
+        IF update_user_id_found = 'f' THEN
+            NEW.update_user_id := CURRENT_USER;
+        END IF;
+        RETURN NEW;
+    END; 
+$function$
+;
+
+CREATE TRIGGER parkarea_set_default_audit_values
+BEFORE update on shared.park_area
+FOR EACH ROW
+EXECUTE FUNCTION shared.update_audit_columns();  


### PR DESCRIPTION
# Description

These are database triggers on the case management side to update user and timestamp automatically if not provided. 

Fixes # (CE-177)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Inspect Migrations container log file. Check if there are no errors. If feasible connect to the database and check that triggers are there. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes